### PR TITLE
Ego and Collapse options

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -290,16 +290,20 @@ class syntax_plugin_dir extends DokuWiki_Syntax_Plugin {
    * Get the namespace of the parent directory
    * (always prefixed and postfixed with a colon, root is ':')
    */
-  function _getParentNS () {
+  function _getParentNS ($id) {
     
-    global $ID ;
+    // global $ID ;
     
-    $curNS = getNS ($ID) ;
+    $curNS = getNS ($id) ;
     
     if ($curNS == '')
       return ':' ;
     
-    return ':' . $curNS . ':' ;
+    if (substr ($curNS, 0, 1) != ':') {
+      $curNS = ':' . $curNS;
+    }
+
+    return $curNS . ':' ;
   }
    
   /**
@@ -315,9 +319,9 @@ class syntax_plugin_dir extends DokuWiki_Syntax_Plugin {
     if (substr ($ns, 0, 2) == '.:') {
       $ns = ':' . getNS ($ID) . substr ($ns, 1) ;
     } elseif (substr ($ns, 0, 3) == '..:') {
-      $ns = $this->_getParentNS () . substr ($ns, 3) ;
+      $ns = $this->_getParentNS ($ID) . substr ($ns, 3) ;
     } elseif ($ns == '..') {
-      $ns = $this->_getParentNS () ;
+      $ns = $this->_getParentNS ($ID) ;
     } elseif (substr ($ns, 0, 1) == ':') {
     } elseif ($ns == '.' || $ns == '*') {
       $ns = ':' . getNS ($ID) ;


### PR DESCRIPTION
Hi,

I have added two new options to the dir plugin: ego and commit.
- ego: By default, the current page (being the one which holds the dir call) is not included in the list generated by the plugin. With this option is set, the current page will be included provided it is in the selected list of namespaces.
- collapse: this option allows the list to be trimmed. By default all pages found in the selected namespaces and their child namespaces are listed. With the collapse option set, the list will contain only:
  - the pages in the selected namespaces,
  - the start pages of all immediate child namespaces,
  - the start pages of all sibling namespaces,
  - the start pages for any parent namespace
  - the start pages for any parent's siblings
    This option can be very useful for navigation to limit the size of a list to only the information that is immediatly relevant relative to the current page.

Geert
