### PR TITLE
Fix row numbering

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -1033,8 +1033,10 @@ class syntax_plugin_dir extends DokuWiki_Syntax_Plugin {
      * Rewrite of renderer->table_open () because of class
      */
     function _tableOpen() {
+        $rdr = $this->rdr;
+        $rdr->_counter['row_counter'] = 0;
+        
         if($this->modeIsLatex) {
-            $rdr                    = $this->rdr;
             $rdr->_current_tab_cols = 0;
             if($rdr->info ['usetablefigure'] == "on") {
                 $this->_putCmdNl("begin{figure}[h]");


### PR DESCRIPTION
The variable `_counter['row_counter']` wasn't declared in the reimplementation of `_tableOpen()` which means that row numbers were continuing from previous tables and that header row had the class `row` instead of `row0` which was breaking some templates.
