### PR TITLE
Prevent crash in current dokuwiki version (2014-09-29a "Hrun")

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -1057,10 +1057,10 @@ class syntax_plugin_dir extends DokuWiki_Syntax_Plugin {
      * Rewrite of renderer->table_open () because of class
      */
     function _tableOpen() {
-        $rdr = $this->rdr;
-        $rdr->_counter['row_counter'] = 0;
-        
+
         if($this->modeIsLatex) {
+            $rdr = $this->rdr;
+            $rdr->_counter['row_counter'] = 0;
             $rdr->_current_tab_cols = 0;
             if($rdr->info ['usetablefigure'] == "on") {
                 $this->_putCmdNl("begin{figure}[h]");


### PR DESCRIPTION
The Renderer counter is not resetted if render mode is not latex.
This prevents a PHP error when the protected _counter property is
accessed.